### PR TITLE
Pass all credential data

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,13 @@ angular.module('myModule', ['Devise']).
     });
 ```
 
-### Auth.login(opts)
+### Auth.login(creds)
 
 Use `Auth.login()` to authenticate with the server. Keep in mind,
 credentials are sent in plaintext; use a SSL connection to secure them.
-`opts` is an object which should contain the email and password of the
-user trying to login. `Auth.login()` will return a promise that will resolve
-to the logged-in user.
+`creds` is an object which should contain any credentials needed to
+authenticate with the server. `Auth.login()` will return a promise that
+will resolve to the logged-in user.
 
 ```javascript
 angular.module('myModule', ['Devise']).
@@ -123,7 +123,7 @@ angular.module('myModule', ['Devise']).
         };
 
         Auth.login(credentials).then(function(user) {
-            // You have a user!
+            console.log(user); // => {id: 1, ect: '...'}
         }, function(error) {
             // Authentication failed...
         });
@@ -153,6 +153,8 @@ angular.module('myModule', ['Devise']).
         // ...
         Auth.logout().then(function(oldUser) {
             // alert(oldUser.name + "you're signed out now.");
+        }, function(error) {
+            // An error occurred logging out.
         });
     });
 ```
@@ -168,15 +170,13 @@ angular.module('myModule', ['Devise']).
     });
 ```
 
-### Auth.register(opts)
+### Auth.register(creds)
 
 Use `Auth.register()` to register and authenticate with the server. Keep
 in mind, credentials are sent in plaintext; use a SSL connection to
-secure them. `opts` is an object that should contain at least an email
-and password. Additionally, `opts.password_confirmation` may be
-provided, though it will default to `opts.password` if it is not.
-`Auth.register()` will return a promise that will resolve to the
-registered user.
+secure them. `creds` is an object that should contain any credentials
+needed to register with the server. `Auth.register()` will return a
+promise that will resolve to the registered user.
 
 ```javascript
 angular.module('myModule', ['Devise']).
@@ -184,12 +184,11 @@ angular.module('myModule', ['Devise']).
         var credentials = {
             email: 'user@domain.com',
             password: 'password1',
-            password_confirmation: 'password1' // though it will default
-                                               // to credentials.password
+            password_confirmation: 'password1'
         };
 
         Auth.register(credentials).then(function(registeredUser) {
-            // Registration successful!
+            console.log(registeredUser); // => {id: 1, ect: '...'}
         }, function(error) {
             // Registration failed...
         });
@@ -197,7 +196,7 @@ angular.module('myModule', ['Devise']).
 ```
 
 By default, `register` will POST to '/users.json'. The path and HTTP
-method used to login are configurable using
+method used to register are configurable using:
 
 ```javascript
 angular.module('myModule', ['Devise']).

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,24 +1,4 @@
 devise.provider('Auth', function AuthProvider() {
-    // Cache a reference to slice.
-    var slice = Array.prototype.slice;
-
-    /**
-     * Picks properties out of an object.
-     * @param {Object} obj The object to pick out of.
-     * @param {...String} props The properties to pick out.
-     */
-    function pick(old) {
-        var obj = {};
-        if (!old) { return obj; }
-        var props = slice.call(arguments, 1);
-        var l = props.length;
-        var prop;
-        while ((prop = props[--l])) {
-            if (prop in old) { obj[prop] = old[prop]; }
-        }
-        return obj;
-    }
-
     /**
      * The default paths.
      */
@@ -89,15 +69,13 @@ devise.provider('Auth', function AuthProvider() {
              *      AuthProvider.loginMethod('GET');
              *  });
              *
-             * @param {Object} [opts] A hash of user credentials.
-             * @param {String} [opts.email] The email of the user
-             * @param {String} [opts.password] The password of the user
+             * @param {Object} [creds] A hash of user credentials.
              * @returns {Promise} A $http promise that will be resolved or
              *                  rejected by the server.
              */
-            login: function(opts) {
-                var user = pick(opts, 'email', 'password');
-                return $http[method('login')](path('login'), {user: user}).then(function(response) {
+            login: function(creds) {
+                creds = creds || {};
+                return $http[method('login')](path('login'), {user: creds}).then(function(response) {
                     service.currentUser = response.data;
                     return service.requestCurrentUser();
                 });
@@ -141,20 +119,13 @@ devise.provider('Auth', function AuthProvider() {
              *      AuthProvider.registerMethod('GET');
              *  });
              *
-             * @param {Object} [opts] A hash of user credentials.
-             * @param {String} [opts.email] The email of the user
-             * @param {String} [opts.password] The password of the user
-             * @param {String} [opts.password_confirmation] The retyped password.
-             *                  Will default to opts.password if none is given.
+             * @param {Object} [creds] A hash of user credentials.
              * @returns {Promise} A $http promise that will be resolved or
              *                  rejected by the server.
              */
-            register: function(opts) {
-                var user = pick(opts, 'email', 'password', 'password_confirmation');
-                if (!user.password_confirmation) {
-                    user.password_confirmation = user.password;
-                }
-                return $http[method('register')](path('register'), {user: user}).then(function(response) {
+            register: function(creds) {
+                creds = creds || {};
+                return $http[method('register')](path('register'), {user: creds}).then(function(response) {
                     service.currentUser = response.data;
                     return service.requestCurrentUser();
                 });

--- a/test/spec/auth.js
+++ b/test/spec/auth.js
@@ -99,17 +99,8 @@ describe('Provider: Devise.Auth', function () {
             $httpBackend.flush();
         });
 
-        it('POSTS user.email data', function() {
-            var u = {email: 'test'};
-            postCallback = function(data) {
-                return jsonEquals(data.user, u);
-            };
-            Auth.login(u);
-            $httpBackend.flush();
-        });
-
-        it('POSTS user.password data', function() {
-            var u = {password: 'test'};
+        it('POSTS credential data', function() {
+            var u = {email: 'test', blah: true};
             postCallback = function(data) {
                 return jsonEquals(data.user, u);
             };
@@ -192,37 +183,10 @@ describe('Provider: Devise.Auth', function () {
             $httpBackend.flush();
         });
 
-        it('POSTS user.email data', function() {
-            var u = {email: 'test'};
+        it('POSTS credential data', function() {
+            var u = {email: 'test', blah: true};
             postCallback = function(data) {
                 return jsonEquals(data.user, u);
-            };
-            Auth.register(u);
-            $httpBackend.flush();
-        });
-
-        it('POSTS user.password data', function() {
-            var u = {password: 'test'};
-            postCallback = function(data) {
-                return data.user.password === u.password;
-            };
-            Auth.register(u);
-            $httpBackend.flush();
-        });
-
-        it('POSTS user.password_confirmation data', function() {
-            var u = {password_confirmation: 'test'};
-            postCallback = function(data) {
-                return jsonEquals(data.user, u);
-            };
-            Auth.register(u);
-            $httpBackend.flush();
-        });
-
-        it('POSTS user.password_confirmation from user.password if password_confirmation not set', function() {
-            var u = {password: 'test'};
-            postCallback = function(data) {
-                return data.user.password_confirmation === data.user.password;
             };
             Auth.register(u);
             $httpBackend.flush();


### PR DESCRIPTION
Instead of selecting which credentials to pass to the server, just pass
them all.

The previous behaviour was to allow ajax options to be passed as well,
but that was refactored out.
