### PR TITLE
Make currentUser a promise returning function

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,46 +46,45 @@ angular.module('myModule', ['Devise']).
     });
 ```
 
-### Auth.currentUser
+### Auth._currentUser
 
-`Auth.currentUser` will contain either `null` or the currentUser's
+`Auth._currentUser` will be either `null` or the currentUser's
 object representation. It is not recommended to directly access
-`Auth.currentUser`, but instead use
-[Auth.requestCurrentUser()](authrequestcurrentuser).
+`Auth._currentUser`, but instead use
+[Auth.currentUser()](authcurrentuser).
 
 ```javascript
 angular.module('myModule', ['Devise']).
     controller('myCtrl', function(Auth) {
-        console.log(Auth.currentUser); // => null
+        console.log(Auth._currentUser); // => null
 
         // Log in user...
 
-        console.log(Auth.currentUser); // => {id: 1, ect: '...'}
+        console.log(Auth._currentUser); // => {id: 1, ect: '...'}
     });
 ```
 
-### Auth.requestCurrentUser()
+### Auth.currentUser()
 
-`Auth.requestCurrentUser()` returns a promise that will be resolved into
+`Auth.currentUser()` returns a promise that will be resolved into
 the currentUser. There are three possible outcomes:
 
-*  1. Auth has authenticated a user, and will resolve with it
-*  2. Auth has not authenticated a user but the server has an
-        authenticated session, Auth will attempt to retrieve that
-        session and resolve with its user.
-*  3. Neither Auth nor the server has an authenticated session,
-        and will reject with an unauthenticated error.
+ 1. Auth has authenticated a user, and will resolve with it
+ 2. Auth has not authenticated a user but the server has a previously
+    authenticated session, Auth will attempt to retrieve that
+    session and resolve with its user.
+ 3. Neither Auth nor the server has an authenticated session,
+    and will reject with an unauthenticated error.
 
 ```javascript
 angular.module('myModule', ['Devise']).
     controller('myCtrl', function(Auth) {
-        Auth.requestCurrentUser(); // A rejected promise since no one's
-                                   // logged in.
-
-        // Log in user...
-
-        Auth.requestCurrentUser().then(function(user) {
+        Auth.currentUser().then(function(user) {
+            // User was logged in, or Devise returned
+            // previously authenticated session.
             console.log(user); // => {id: 1, ect: '...'}
+        }, function(error) {
+            // unauthenticated error
         });
     });
 ```
@@ -93,7 +92,7 @@ angular.module('myModule', ['Devise']).
 ### Auth.isAuthenticated()
 
 `Auth.isAuthenticated()` is a helper method to determine if a
-currentUser is present.
+currentUser is logged in with Auth.
 
 ```javascript
 angular.module('myModule', ['Devise']).

--- a/src/auth.js
+++ b/src/auth.js
@@ -72,7 +72,7 @@ devise.provider('Auth', function AuthProvider() {
              * This is shared between all instances of Auth
              * on the scope.
              */
-            currentUser: null,
+            _currentUser: null,
 
             /**
              * A login function to authenticate with the server.
@@ -98,8 +98,8 @@ devise.provider('Auth', function AuthProvider() {
             login: function(opts) {
                 var user = pick(opts, 'email', 'password');
                 return $http[method('login')](path('login'), {user: user}).then(function(response) {
-                    service.currentUser = response.data;
-                    return service.requestCurrentUser();
+                    service._currentUser = response.data;
+                    return service.currentUser();
                 });
             },
 
@@ -120,8 +120,8 @@ devise.provider('Auth', function AuthProvider() {
              */
             logout: function() {
                 return $http[method('logout')](path('logout')).then(function() {
-                    var oldUser = service.currentUser;
-                    service.currentUser = null;
+                    var oldUser = service._currentUser;
+                    service._currentUser = null;
                     return oldUser;
                 });
             },
@@ -155,8 +155,8 @@ devise.provider('Auth', function AuthProvider() {
                     user.password_confirmation = user.password;
                 }
                 return $http[method('register')](path('register'), {user: user}).then(function(response) {
-                    service.currentUser = response.data;
-                    return service.requestCurrentUser();
+                    service._currentUser = response.data;
+                    return service.currentUser();
                 });
             },
 
@@ -173,9 +173,9 @@ devise.provider('Auth', function AuthProvider() {
              * @returns {Promise} A $http promise that will be resolved or
              *                  rejected by the server.
              */
-            requestCurrentUser: function() {
+            currentUser: function() {
                 if (service.isAuthenticated()) {
-                    return $q.when(service.currentUser);
+                    return $q.when(service._currentUser);
                 }
                 return service.login();
             },
@@ -186,7 +186,7 @@ devise.provider('Auth', function AuthProvider() {
              * @returns Boolean
              */
             isAuthenticated: function(){
-                return !!service.currentUser;
+                return !!service._currentUser;
             }
         };
 

--- a/test/spec/auth.js
+++ b/test/spec/auth.js
@@ -18,7 +18,7 @@ describe('Provider: Devise.Auth', function () {
     }));
     function forceSignIn(Auth, user) {
         user = (user === undefined) ? {} : user;
-        Auth.currentUser = user;
+        Auth._currentUser = user;
         return user;
     }
     function jsonEquals(obj, other) {
@@ -154,7 +154,7 @@ describe('Provider: Devise.Auth', function () {
         });
 
         it('resolves promise to old currentUser', function() {
-            var user = Auth.currentUser = {id: 0};
+            var user = forceSignIn(Auth, {id: 0});
             var callback = jasmine.createSpy('callback');
             Auth.logout().then(callback);
 
@@ -245,7 +245,7 @@ describe('Provider: Devise.Auth', function () {
         });
     });
 
-    describe('.requestCurrentUser', function() {
+    describe('.currentUser', function() {
         describe('when authenticated', function() {
             var user;
             beforeEach(function() {
@@ -255,7 +255,7 @@ describe('Provider: Devise.Auth', function () {
             it('returns a promise', function() {
                 var callback = jasmine.createSpy('callback');
 
-                Auth.requestCurrentUser().then(callback);
+                Auth.currentUser().then(callback);
                 // use #$apply to have the promise resolve.
                 $rootScope.$apply();
 
@@ -265,7 +265,7 @@ describe('Provider: Devise.Auth', function () {
             it('resolves the promise with the currentUser', function() {
                 var callback = jasmine.createSpy('callback');
 
-                Auth.requestCurrentUser().then(callback);
+                Auth.currentUser().then(callback);
                 // use #$apply to have the promise resolve.
                 $rootScope.$apply();
 
@@ -281,7 +281,7 @@ describe('Provider: Devise.Auth', function () {
                 });
 
                 it('fetches user from server', function() {
-                    Auth.requestCurrentUser();
+                    Auth.currentUser();
                     $httpBackend.flush();
                     $httpBackend.verifyNoOutstandingExpectation();
                     $httpBackend.verifyNoOutstandingRequest();
@@ -289,7 +289,7 @@ describe('Provider: Devise.Auth', function () {
 
                 it('resolves promise with fetched user', function() {
                     var callback = jasmine.createSpy('callback');
-                    Auth.requestCurrentUser().then(callback);
+                    Auth.currentUser().then(callback);
                     $httpBackend.flush();
 
                     // use #$apply to have the promise resolve.
@@ -307,7 +307,7 @@ describe('Provider: Devise.Auth', function () {
 
                 it('rejects promise with error', function() {
                     var callback = jasmine.createSpy('callback');
-                    Auth.requestCurrentUser().catch(callback);
+                    Auth.currentUser().catch(callback);
                     $httpBackend.flush();
 
                     // use #$apply to have the promise resolve.


### PR DESCRIPTION
Since accessing the user object directly is discouraged anyway, set it
as a "private" variable on Auth. Rename .requestCurrentUser() ->
.currentUser(), since it was the preferred way to get the currentUser.
