### PR TITLE
Update README.md with the correct application.js 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ end
 Then `bundle`. Finally, to require the JS:
 
 ```js
-//= require angular-devise/lib/devise
+//= require angular-devise
 ```
 
 Usage


### PR DESCRIPTION
Turns out the correct Rails asset include is:

    //= require angular-devise