### PR TITLE
fix wrong sprocket require

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ end
 Then `bundle`. Finally, to require the JS:
 
 ```js
-//= require angular-devise/lib/devise
+//= require angular-devise
 ```
 
 Usage


### PR DESCRIPTION
It seems that correct way to include this assets file is to specify
the asset name, rather then a /lib/... full path. Tested with Bundler
1.10.

Signed-off-by: zeljko <zeljko@z-ware.fi>