### PR TITLE
Don't assume response object has a config property

### DIFF
--- a/lib/devise.js
+++ b/lib/devise.js
@@ -19,7 +19,7 @@
         return {
             responseError: function(response) {
                 // Determine if the response is specifically disabling the interceptor.
-                var intercept = response.config.interceptAuth;
+                var intercept = (response.config || {}).interceptAuth;
                 intercept = !!intercept || (interceptAuth && intercept === void 0);
 
                 if (intercept && response.status === 401) {


### PR DESCRIPTION
In our environment whenever the `$http` stack blows up the interceptor is called and itself blows up swallowing the error. This fixes that.